### PR TITLE
Update install, systemd, user, pillar, templates.

### DIFF
--- a/minio/files/minio.etc.default.jinja
+++ b/minio/files/minio.etc.default.jinja
@@ -1,7 +1,7 @@
 # Remote volumes to be used for MinIO server.
 MINIO_VOLUMES={{ minio_volumes }}
 # Use if you want to run MinIO on a custom port.
-MINIO_OPTS={{ minio_opts }}
+MINIO_PORT={{ minio_port }}
 # Access Key of the server.
 MINIO_ACCESS_KEY={{ minio_access_key }}
 # Secret key of the server.

--- a/minio/files/minio.service.jinja
+++ b/minio/files/minio.service.jinja
@@ -16,7 +16,7 @@ ExecStartPre=/bin/bash -c "if [ -z \"${MINIO_VOLUMES}\" ]; then echo \"Variable 
 ExecStartPre=/bin/bash -c "if [ -z \"${MINIO_ACCESS_KEY}\" ]; then echo \"Variable MINIO_ACCESS_KEY not set in /etc/default/minio\"; exit 1; fi"
 ExecStartPre=/bin/bash -c "if [ -z \"${MINIO_SECRET_KEY}\" ]; then echo \"Variable MINIO_SECRET_KEY not set in /etc/default/minio\"; exit 1; fi"
 
-ExecStart=/usr/local/bin/minio server $MINIO_OPTS $MINIO_VOLUMES
+ExecStart=/usr/local/bin/minio server --address :${MINIO_PORT} $MINIO_VOLUMES
 
 # Let systemd restart this service always
 Restart=always

--- a/minio/install.sls
+++ b/minio/install.sls
@@ -2,10 +2,24 @@
   Salt State to Install and Configure Minio https://min.io/
 #}
 
+{% set minio_user = salt['pillar.get']('minio:user') %}
+{% set minio_group = salt['pillar.get']('minio:group') %}
 {% set minio_release = salt['pillar.get']('minio:release') %}
 {% set minio_platform = salt['pillar.get']('minio:platform') %}
 {% set minio_download_url = salt['pillar.get']('minio:download_url') %}
 {% set minio_install_path = salt['pillar.get']('minio:install_path') %}
+
+etc_minio:
+  file.directory:
+    - name: /etc/minio/certs
+    - user: {{ minio_user }}
+    - group: {{ minio_group }}
+    - mode: 755
+    - makedirs: True
+    - recurse:
+      - user
+      - group
+      - mode
 
 minio_binary:
   file.managed:

--- a/minio/systemd.sls
+++ b/minio/systemd.sls
@@ -11,7 +11,7 @@
 {% set minio_browser = salt['pillar.get']('minio:browser') %}
 {% set minio_drive_sync = salt['pillar.get']('minio:drive_sync') %}
 {% set minio_http_trace = salt['pillar.get']('minio:http_trace') %}
-{% set minio_opts = salt['pillar.get']('minio:opts') %}
+{% set minio_port = salt['pillar.get']('minio:port') %}
 
 minio_systemd_service:
   file.managed:
@@ -41,4 +41,12 @@ minio_etc_default:
         minio_browser: {{ minio_browser }}
         minio_drive_sync: {{ minio_drive_sync }}
         minio_http_trace: {{ minio_http_trace }}
-        minio_opts: {{ minio_opts }}
+        minio_port: {{ minio_port }}
+
+minio_enable_service:
+  service.enabled:
+    - name: minio
+
+minio_start_service:
+  service.running:
+    - name: minio

--- a/minio/user.sls
+++ b/minio/user.sls
@@ -7,15 +7,14 @@
 {% set minio_uid = salt['pillar.get']('minio:uid') %}
 {% set minio_gid = salt['pillar.get']('minio:gid') %}
 
-{{ minio_group }}:
+minio_group:
   group.present:
     - name: {{ minio_group }}
     - gid: {{ minio_gid }}
-    - system: {{ minio_group_system }}
 
-{{ minio_user }}:
+minio_user:
   user.present:
+    - name: {{ minio_user }}
     - shell: /sbin/nologin
     - uid: {{ minio_uid }}
     - gid: {{ minio_guid }}
-

--- a/pillar.example
+++ b/pillar.example
@@ -13,8 +13,8 @@ minio:
   volumes: http://node{1...6}/export{1...32}
   browser: off
   drive_sync: on
-  http_trace: 
-  opts: "--address :9199"
+  http_trace: /var/log/minio.log
+  port: 9000
 
 # **NOTE:** browser and drive_sync options will be ignored 
 # They are keep here for informational purposes.


### PR DESCRIPTION
**install.sls**
  - Add minio_user variable
  - Add minio_group variable
  - Add etc_minio file.directory

The etc_minio file.directory should create the `/etc/minio/certs`
and set the permissions for the minio user and group. Even if minio
is configured to run without SSL, it will refuse to start if it can't
access the certs directory.

**pillar.example**
  - Update *http_trace* set a defalt log file.
  - Updte replace *opts* with *port* option.

Minio disables the logging by default(http_trace: set to blank), but
yaml renders `None`, and the server refuses to start in this condition.
Set a default logfile to avoid that.
Replace *opts* with *port*. Eventually we can add *address* but with
the issues regarding blank options, better to not add it right now.

**minio.etc.default.jinja**
  - Replace MINIO_OPTS with MINIO_PORT

**minio.service.jinja**
  - Update `ExecStart`, replace MINIO_OPTS with MINIO_PORT

**systemd.sls**
  - Replace `minio_opts` with `minio_port`
  - Add minio_enable_service
  - Add minio_start_service

**user.sls**
  - Update group task ID
  - Delete group.present.system
  - Update user task ID
  - Add user.present.name